### PR TITLE
Case sensitivity - backwards compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ It will run on as many threads as cpu's are available.
 - `character_frequencies_with_n_threads(text: &str, threads: usize) -> HashMap<char, usize>`:
 Returns a map with the frequencies counted on the text parameter.
 It will run on the specified ammount of threads.
+- `character_frequencies_with_case(text: &str,Case::Sensitive) -> HashMap<char, usize>`
+- `character_frequencies_with_n_threads_with_case(text: &str, threads: usize,Case::Sensitive) -> HashMap<char, usize>`:
+Identical to above but with case sensitivity turned on (so 'A' will be counted separate from 'a')
 
 ## Example
 This example counts the character frequencies of `Hello, World!` and print them afterwards:

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ It will run on as many threads as cpu's are available.
 - `character_frequencies_with_n_threads(text: &str, threads: usize) -> HashMap<char, usize>`:
 Returns a map with the frequencies counted on the text parameter.
 It will run on the specified ammount of threads.
-- `character_frequencies_with_case(text: &str,Case::Sensitive) -> HashMap<char, usize>`
-- `character_frequencies_with_n_threads_with_case(text: &str, threads: usize,Case::Sensitive) -> HashMap<char, usize>`:
+- `character_frequencies_with_case(text: &str,case:Case) -> HashMap<char, usize>`
+- `character_frequencies_with_n_threads_with_case(text: &str, threads: usize,case:Case) -> HashMap<char, usize>`:
 Identical to above but with case sensitivity turned on (so 'A' will be counted separate from 'a')
 
 ## Example
@@ -25,4 +25,7 @@ println!("Character frequencies:");
 for (character, frequency) in frequency_map {
     println!("\'{}\': {}", character, frequency);
 }
+
+let frequency_map2 = character_frequencies("Hello, World!",Case::Sensitive);
+
 ```

--- a/README.md
+++ b/README.md
@@ -26,6 +26,6 @@ for (character, frequency) in frequency_map {
     println!("\'{}\': {}", character, frequency);
 }
 
-let frequency_map2 = character_frequencies("Hello, World!",Case::Sensitive);
+let frequency_map2 = character_frequencies_with_case("Hello, World!",Case::Sensitive);
 
 ```

--- a/README.md
+++ b/README.md
@@ -26,6 +26,6 @@ for (character, frequency) in frequency_map {
     println!("\'{}\': {}", character, frequency);
 }
 
-let frequency_map2 = character_frequencies_with_case("Hello, World!",Case::Sensitive);
+let frequency_map2 = character_frequencies_with_case("HeLlO, WoRLd!",Case::Sensitive);
 
 ```


### PR DESCRIPTION
The original crate converted everything to ascii lowercase. This allows for that to be chosen by the user at runtime. 

This gives the user an option to make the matching case-sensitive. 

It is also backwards compatible, since it adds new functions instead of changing existing functions. 

Thanks