### PR TITLE
case sensitivity - try # 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Same as character_frequencies() but with Case Sensitive counting
 - `character_frequencies_with_n_threads_w_case(text: &str,case:CaseSense) -> HashMap<char, usize>`
 Same as character_frequencies_with_n_threads() but with Case Sensitive counting
 
+### Enums
+
 - `CaseSense::InsensitiveASCIIOnly` - Converts ASCII characters to lowercase before counting
  This is the default.
 - `CaseSense::Insensitive` - Converts all UTF8 characters to lowercase before counting.  If

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ It will run on the specified ammount of threads.
 
 ## Example
 This example counts the character frequencies of `Hello, World!` and print them afterwards:
+
 ```rust
 use character_frequency::*;
 
@@ -22,4 +23,15 @@ println!("Character frequencies:");
 for (character, frequency) in frequency_map {
     println!("\'{}\': {}", character, frequency);
 }
+Character frequencies:
+'r': 1
+'d': 1
+'o': 2
+'!': 1
+',': 1
+' ': 1
+'e': 1
+'h': 1
+'w': 1
+'l': 3
 ```

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ Same as character_frequencies() but with Case Sensitive counting
 Same as character_frequencies_with_n_threads() but with Case Sensitive counting
 
 CaseSense:
--InsensitiveASCIIOnly - Converts ASCII characters to lowercase before counting
+- `InsensitiveASCIIOnly - Converts ASCII characters to lowercase before counting
  This is the default.
--Insensitive - Converts all UTF8 characters to lowercase before counting.  If
+- `Insensitive - Converts all UTF8 characters to lowercase before counting.  If
  the character's lowercase version is a string not a character, it panics. 
--Sensitive - Doesn't convert any characters to lowercase before counting. 
+- `Sensitive - Doesn't convert any characters to lowercase before counting. 
 
 ## Example
 This example counts the character frequencies of `Hello, World!` and print them afterwards:

--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@ It will run on as many threads as cpu's are available.
 - `character_frequencies_with_n_threads(text: &str, threads: usize) -> HashMap<char, usize>`:
 Returns a map with the frequencies counted on the text parameter.
 It will run on the specified ammount of threads.
+- `character_frequencies_w_case(text: &str,case:CaseSense) -> HashMap<char, usize>`
+Same as character_frequencies() but with Case Sensitive counting
+- `character_frequencies_with_n_threads_w_case(text: &str,case:CaseSense) -> HashMap<char, usize>`
+Same as character_frequencies_with_n_threads() but with Case Sensitive counting
+
+CaseSense:
+-InsensitiveASCIIOnly - Converts ASCII characters to lowercase before counting
+ This is the default.
+-Insensitive - Converts all UTF8 characters to lowercase before counting.  If
+ the character's lowercase version is a string not a character, it panics. 
+-Sensitive - Doesn't convert any characters to lowercase before counting. 
 
 ## Example
 This example counts the character frequencies of `Hello, World!` and print them afterwards:
@@ -21,17 +32,18 @@ let frequency_map = character_frequencies("Hello, World!");
 
 println!("Character frequencies:");
 for (character, frequency) in frequency_map {
-    println!("\'{}\': {}", character, frequency);
+    print!("\'{}\': {}", character, frequency);
 }
-Character frequencies:
-'r': 1
-'d': 1
-'o': 2
-'!': 1
-',': 1
-' ': 1
-'e': 1
-'h': 1
-'w': 1
-'l': 3
+//Character frequencies:
+//'r': 1 'd': 1 'o': 2 '!': 1 ',': 1 ' ': 1 'e': 1 'h': 1 'w': 1 'l': 3
+
+let frequency_map = character_frequencies("Hello WORLD",CaseSense::Sensitive);
+
+println!("Character frequencies:");
+for (character, frequency) in frequency_map {
+    print!("\'{}\': {}", character, frequency);
+}
+//Character frequencies:
+//'R': 1 'D': 1 'O': 1 'o': 1 ' ': 1 'e': 1 'H': 1 'W': 1 'l': 2 'L': 1
+
 ```

--- a/README.md
+++ b/README.md
@@ -15,12 +15,11 @@ Same as character_frequencies() but with Case Sensitive counting
 - `character_frequencies_with_n_threads_w_case(text: &str,case:CaseSense) -> HashMap<char, usize>`
 Same as character_frequencies_with_n_threads() but with Case Sensitive counting
 
-CaseSense:
-- `InsensitiveASCIIOnly - Converts ASCII characters to lowercase before counting
+- `CaseSense::InsensitiveASCIIOnly` - Converts ASCII characters to lowercase before counting
  This is the default.
-- `Insensitive - Converts all UTF8 characters to lowercase before counting.  If
+- `CaseSense::Insensitive` - Converts all UTF8 characters to lowercase before counting.  If
  the character's lowercase version is a string not a character, it panics. 
-- `Sensitive - Doesn't convert any characters to lowercase before counting. 
+- `CaseSense::Sensitive` - Doesn't convert any characters to lowercase before counting. 
 
 ## Example
 This example counts the character frequencies of `Hello, World!` and print them afterwards:

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ let frequency_map = character_frequencies("Hello, World!");
 
 println!("Character frequencies:");
 for (character, frequency) in frequency_map {
-    print!("\'{}\': {}", character, frequency);
+    print!("\'{}\': {},", character, frequency);
 }
 //Character frequencies:
 //'r': 1 'd': 1 'o': 2 '!': 1 ',': 1 ' ': 1 'e': 1 'h': 1 'w': 1 'l': 3
@@ -46,7 +46,7 @@ let frequency_map = character_frequencies_w_case("Hello WORLD",CaseSense::Sensit
 
 println!("Character frequencies:");
 for (character, frequency) in frequency_map {
-    print!("\'{}\': {}", character, frequency);
+    print!("\'{}\': {},", character, frequency);
 }
 //Character frequencies:
 //'R': 1 'D': 1 'O': 1 'o': 1 ' ': 1 'e': 1 'H': 1 'W': 1 'l': 2 'L': 1

--- a/README.md
+++ b/README.md
@@ -17,10 +17,9 @@ Same as character_frequencies_with_n_threads() but with Case Sensitive counting
 
 ### Enums
 
-- `CaseSense::InsensitiveASCIIOnly` - Converts ASCII characters to lowercase before counting
- This is the default.
-- `CaseSense::Insensitive` - Converts all UTF8 characters to lowercase before counting.  If
- the character's lowercase version is a string not a character, it panics. 
+- `CaseSense::InsensitiveASCIIOnly` - Converts ASCII characters to lowercase before counting. This is the default.
+- `CaseSense::Insensitive` - Converts all UTF8 characters to lowercase before counting.  If the Unicode
+character's lowercase version is a string, not a character, it panics. 
 - `CaseSense::Sensitive` - Doesn't convert any characters to lowercase before counting. 
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -37,8 +37,12 @@ for (character, frequency) in frequency_map {
 }
 //Character frequencies:
 //'r': 1 'd': 1 'o': 2 '!': 1 ',': 1 ' ': 1 'e': 1 'h': 1 'w': 1 'l': 3
+```
 
-let frequency_map = character_frequencies("Hello WORLD",CaseSense::Sensitive);
+This does the same but with case sensitivity.
+
+```rust
+let frequency_map = character_frequencies_w_case("Hello WORLD",CaseSense::Sensitive);
 
 println!("Character frequencies:");
 for (character, frequency) in frequency_map {

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -3,7 +3,8 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use std::fs;
 
 fn character_frequency_benchmark(c: &mut Criterion) {
-    let text = fs::read_to_string("benches/bench_text.txt").expect("File not found");
+	let filename = "benches/bench_text.txt";
+    let text = fs::read_to_string(filename).expect(&format!("File not found: {}",filename));
     c.bench_function("sequential", |b| {
         b.iter(|| sequential_character_frequencies(black_box(&text)))
     });

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -1,0 +1,10 @@
+use character_frequency::*;
+
+fn main() {
+    let frequency_map = character_frequencies("Hello, World!");
+
+    println!("Character frequencies:");
+    for (character, frequency) in frequency_map {
+        println!("\'{}\': {}", character, frequency);
+    }
+}

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -8,10 +8,10 @@ fn main() {
         println!("\'{}\': {}", character, frequency);
     }
 
-    let frequency_map = character_frequencies_w_case("Hello, WORLD", CaseSense::Sensitive);
+    let frequency_map_s = character_frequencies_w_case("Hello, WORLD", CaseSense::Sensitive);
 
     println!("Character frequencies (case sensitive):");
-    for (character, frequency) in frequency_map {
+    for (character, frequency) in frequency_map_s {
         println!("\'{}\': {}", character, frequency);
     }
 }

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -7,4 +7,11 @@ fn main() {
     for (character, frequency) in frequency_map {
         println!("\'{}\': {}", character, frequency);
     }
+
+    let frequency_map = character_frequencies_w_case("Hello, WORLD", CaseSense::Sensitive);
+
+    println!("Character frequencies (case sensitive):");
+    for (character, frequency) in frequency_map {
+        println!("\'{}\': {}", character, frequency);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,13 +163,12 @@ mod tests {
     // convenience function for testing
     // given "a4 b3 c2 d1 e1", return hashmap {a:4, b:3, c:2, d;1, e:1}
     fn hashfreq(s: &str) -> HashMap<char, usize> {
-        let mut hm: HashMap<char, usize> = HashMap::new();
-        for i in s.split(" ") {
-            let ch = i.chars().next().unwrap();
-            let num = usize::from_str_radix(i.get(1..).unwrap(), 10).unwrap();
-            hm.insert(ch, num);
-        }
-        hm
+        HashMap::<char, usize>::from_iter(s.split(" ").map(|chunk| {
+            (
+                chunk.chars().next().unwrap(),
+                usize::from_str_radix(chunk.get(1..).unwrap(), 10).unwrap(),
+            )
+        }))
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -430,38 +430,59 @@ mod tests {
     }
 
     #[test]
-    fn test_character_frequencies_unicode() {
+    fn test_unicode_case_sensitive() {
         let greek_upper = "ὈΔΥΣΣΕΎΣ";
         let greek_lower = "ὀδυσσεύς";
         let greek_mix = "ὀδυσσεύςὈΔΥΣΣΕΎΣ";
-        let resultu_s = character_frequencies_w_case(greek_upper, CaseSense::Sensitive);
-        let resultl_s = character_frequencies_w_case(greek_lower, CaseSense::Sensitive);
-        let resultm_s = character_frequencies_w_case(greek_mix, CaseSense::Sensitive);
-        assert_eq!(resultu_s, expected_freq("Ὀ1 Δ1 Υ1 Σ3 Ε1 Ύ1"));
-        assert_eq!(resultl_s, expected_freq("ὀ1 δ1 υ1 σ2 ε1 ς1 ύ1"));
+        let resultu = character_frequencies_w_case(greek_upper, CaseSense::Sensitive);
+        let resultl = character_frequencies_w_case(greek_lower, CaseSense::Sensitive);
+        let resultm = character_frequencies_w_case(greek_mix, CaseSense::Sensitive);
+        assert_eq!(resultu, expected_freq("Ὀ1 Δ1 Υ1 Σ3 Ε1 Ύ1"));
+        assert_eq!(resultl, expected_freq("ὀ1 δ1 υ1 σ2 ε1 ς1 ύ1"));
         assert_eq!(
-            resultm_s,
+            resultm,
             expected_freq("Ὀ1 Δ1 Υ1 Σ3 Ε1 Ύ1 ὀ1 δ1 υ1 σ2 ε1 ς1 ύ1")
         );
-        let resultu_ia = character_frequencies_w_case(greek_upper, CaseSense::InsensitiveASCIIOnly);
-        let resultl_ia = character_frequencies_w_case(greek_lower, CaseSense::InsensitiveASCIIOnly);
-        let resultm_ia = character_frequencies_w_case(greek_mix, CaseSense::InsensitiveASCIIOnly);
-        assert_eq!(resultu_s, resultu_ia);
-        assert_eq!(resultl_s, resultl_ia);
-        assert_eq!(resultm_s, resultm_ia);
-        let resultu_i = character_frequencies_w_case(greek_upper, CaseSense::Insensitive);
-        let resultl_i = character_frequencies_w_case(greek_lower, CaseSense::Insensitive);
-        let resultm_i = character_frequencies_w_case(greek_mix, CaseSense::Insensitive);
-        assert_eq!(resultu_i, expected_freq("ὀ1 δ1 υ1 σ3 ε1 ύ1"));
-        assert_eq!(resultl_i, expected_freq("ὀ1 δ1 υ1 σ2 ε1 ς1 ύ1"));
-        assert_eq!(resultm_i, expected_freq("ὀ2 δ2 υ2 σ5 ε2 ς1 ύ2"));
+	}
+
+    #[test]
+    fn test_unicode_case_insensitiveasciionly() {
+        let greek_upper = "ὈΔΥΣΣΕΎΣ";
+        let greek_lower = "ὀδυσσεύς";
+        let greek_mix = "ὀδυσσεύςὈΔΥΣΣΕΎΣ";
+        let resultu = character_frequencies_w_case(greek_upper, CaseSense::InsensitiveASCIIOnly);
+        let resultl = character_frequencies_w_case(greek_lower, CaseSense::InsensitiveASCIIOnly);
+        let resultm = character_frequencies_w_case(greek_mix, CaseSense::InsensitiveASCIIOnly);
+        assert_eq!(resultu, expected_freq("Ὀ1 Δ1 Υ1 Σ3 Ε1 Ύ1"));
+        assert_eq!(resultl, expected_freq("ὀ1 δ1 υ1 σ2 ε1 ς1 ύ1"));
+        assert_eq!(
+            resultm,
+            expected_freq("Ὀ1 Δ1 Υ1 Σ3 Ε1 Ύ1 ὀ1 δ1 υ1 σ2 ε1 ς1 ύ1")
+        );
+	}
+
+    #[test]
+    fn test_unicode_case_insensitive() {
+        let greek_upper = "ὈΔΥΣΣΕΎΣ";
+        let greek_lower = "ὀδυσσεύς";
+        let greek_mix = "ὀδυσσεύςὈΔΥΣΣΕΎΣ";
+        let resultu = character_frequencies_w_case(greek_upper, CaseSense::Insensitive);
+        let resultl = character_frequencies_w_case(greek_lower, CaseSense::Insensitive);
+        let resultm = character_frequencies_w_case(greek_mix, CaseSense::Insensitive);
+        assert_eq!(resultu, expected_freq("ὀ1 δ1 υ1 σ3 ε1 ύ1"));
+        assert_eq!(resultl, expected_freq("ὀ1 δ1 υ1 σ2 ε1 ς1 ύ1"));
+        assert_eq!(resultm, expected_freq("ὀ2 δ2 υ2 σ5 ε2 ς1 ύ2"));
+	}
+
+    #[test]
+    fn test_unicode_case_irrelevant() {
         let chinese = "夫物芸芸，各復歸其根，歸根曰靜";
-        let expect_c = expected_freq("夫1 物1 芸2 ，2 各1 復1 其1 歸2 根2 曰1 靜1");
+        let expect = expected_freq("夫1 物1 芸2 ，2 各1 復1 其1 歸2 根2 曰1 靜1");
         let resultc_s = character_frequencies_w_case(chinese, CaseSense::Sensitive);
         let resultc_ia = character_frequencies_w_case(chinese, CaseSense::Insensitive);
         let resultc_i = character_frequencies_w_case(chinese, CaseSense::InsensitiveASCIIOnly);
-        assert_eq!(resultc_s, expect_c);
-        assert_eq!(resultc_ia, expect_c);
-        assert_eq!(resultc_i, expect_c);
+        assert_eq!(resultc_s, expect);
+        assert_eq!(resultc_ia, expect);
+        assert_eq!(resultc_i, expect);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,7 +193,7 @@ fn character_frequencies_range(
     for character in text.chars()
         .skip(from)
         .take(to - from + 1)
-		.map(|ch|  match case_sense {
+        .map(|ch|  match case_sense {
             CaseSense::Insensitive => match ch.to_lowercase().len() {
                 1 => ch.to_lowercase().next().unwrap(),
        	        _ => panic!("Unicode character {:?} {} when converted to lowercase is a multicharacter String not a character", ch, ch ),},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,12 +14,14 @@ use std::thread;
 /// * InsensitiveASCIIOnly - ignores case, but only for ASCII characters,
 /// 'A' and 'a' are counted as the same but Greek letter 'Σ' is
 /// counted as different from it's lowercase version 'σ' because it's not ASCII.
-/// Only ascii characters get converted to lowercase.
+/// All ascii characters get converted to lowercase before counting.
 /// InsensitiveASCIIOnly is the default.
 /// * Insensitive - ignores case based on Unicode Derived Core
 /// Property Lowercase, so 'A'=='a' and also 'Σ'=='σ'.
-/// This does not deal with situations where case depends on position
-/// in a word. It changes all UTF8 characters to lowercase one at a time.
+/// This does not deal with situations where case depends on position within
+/// a word. It changes all UTF8 characters to lowercase one at a time.
+/// Some UTF8 characters have a lowercase version that is a string, if that
+/// happens the code will panic!() if Insensitive is the CaseSense.
 /// * Sensitive - Each character is counted separately.
 /// 'A' != 'a' and 'Σ'!='σ'. No characters are changed to lowercase.
 /// see https://doc.rust-lang.org/std/string/struct.String.html#method.to_ascii_lowercase

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,19 +11,19 @@ use std::sync::{mpsc, Arc};
 use std::thread;
 
 /// This allows to count characters in a string while being sensitive to Case.
-/// * InsensitiveASCIIOnly - ignores case, but only for ASCII characters, 
-/// 'A' and 'a' are counted as the same but Greek letter 'Σ' is 
+/// * InsensitiveASCIIOnly - ignores case, but only for ASCII characters,
+/// 'A' and 'a' are counted as the same but Greek letter 'Σ' is
 /// counted as different from it's lowercase version 'σ' because it's not ASCII.
 /// Only ascii characters get converted to lowecase.
 /// For historical reasons, InsensitiveASCIIOnly is the default.
-/// * Insensitive - ignores case based on Unicode Derived Core 
+/// * Insensitive - ignores case based on Unicode Derived Core
 /// Property Lowercase, so 'A'=='a' and also 'Σ'=='σ'.
 /// Note this does not deal with situations where case depends on position
-/// in a word. It changes all UTF8 characters to lowercase one at a time. 
+/// in a word. It changes all UTF8 characters to lowercase one at a time.
 /// * Sensitive - Each character is counted separately.
 /// 'A' != 'a' and 'Σ'!='σ'. No characters are changed to lowercase.
 /// see https://doc.rust-lang.org/std/string/struct.String.html#method.to_ascii_lowercase
-#[derive(Clone,Copy)]
+#[derive(Clone, Copy)]
 pub enum CaseSense {
     Insensitive,
     InsensitiveASCIIOnly,
@@ -60,10 +60,9 @@ pub fn character_frequencies(text: &str) -> HashMap<char, usize> {
     character_frequencies_with_n_threads(text, num_cpus::get())
 }
 
-pub fn character_frequencies_w_case(text: &str,case:CaseSense) -> HashMap<char, usize> {
-    character_frequencies_with_n_threads_w_case(text, num_cpus::get(),case)
+pub fn character_frequencies_w_case(text: &str, case: CaseSense) -> HashMap<char, usize> {
+    character_frequencies_with_n_threads_w_case(text, num_cpus::get(), case)
 }
-
 
 /// Counts the frequencies of chars from a string with the amount of threads specified.
 ///
@@ -92,12 +91,16 @@ pub fn character_frequencies_w_case(text: &str,case:CaseSense) -> HashMap<char, 
 /// # expected.insert(' ', 1);
 /// ```
 pub fn character_frequencies_with_n_threads(text: &str, threads: usize) -> HashMap<char, usize> {
-	character_frequencies_with_n_threads_w_case(text, threads,CaseSense::InsensitiveASCIIOnly)
+    character_frequencies_with_n_threads_w_case(text, threads, CaseSense::InsensitiveASCIIOnly)
 }
 
-pub fn character_frequencies_with_n_threads_w_case(text: &str, threads: usize,case:CaseSense) -> HashMap<char, usize> {
+pub fn character_frequencies_with_n_threads_w_case(
+    text: &str,
+    threads: usize,
+    case: CaseSense,
+) -> HashMap<char, usize> {
     if threads <= 1 {
-        return sequential_character_frequencies_w_case(text,case);
+        return sequential_character_frequencies_w_case(text, case);
     }
 
     let (tx, rx) = mpsc::channel::<HashMap<char, usize>>();
@@ -113,13 +116,13 @@ pub fn character_frequencies_with_n_threads_w_case(text: &str, threads: usize,ca
         chunk_size: usize,
         tx: &Sender<HashMap<char, usize>>,
         shared: &Arc<String>,
-		case: CaseSense
+        case: CaseSense,
     ) {
         let tx = tx.clone();
         let shared = shared.clone();
         thread::spawn(move || {
             let frequency_map =
-                character_frequencies_range(shared.as_str(), from, from + chunk_size - 1,case);
+                character_frequencies_range(shared.as_str(), from, from + chunk_size - 1, case);
             tx.send(frequency_map).unwrap();
         });
     }
@@ -162,34 +165,39 @@ pub fn character_frequencies_with_n_threads_w_case(text: &str, threads: usize,ca
         }
     }
     received.pop().unwrap()
-
 }
 
 pub fn sequential_character_frequencies(text: &str) -> HashMap<char, usize> {
-    character_frequencies_range(text, 0, text.len() - 1,CaseSense::InsensitiveASCIIOnly)
+    character_frequencies_range(text, 0, text.len() - 1, CaseSense::InsensitiveASCIIOnly)
 }
 
-pub fn sequential_character_frequencies_w_case(text: &str,case:CaseSense) -> HashMap<char, usize> {
-    character_frequencies_range(text, 0, text.len() - 1,case)
+pub fn sequential_character_frequencies_w_case(
+    text: &str,
+    case: CaseSense,
+) -> HashMap<char, usize> {
+    character_frequencies_range(text, 0, text.len() - 1, case)
 }
 
 fn character_frequencies_range(
     text: &str,
     from: usize,
-    to: usize, 
-    case_sense:CaseSense
+    to: usize,
+    case_sense: CaseSense,
 ) -> HashMap<char, usize> {
     text.chars()
         .skip(from)
         .take(to - from + 1)
         .map(|ch| match case_sense {
-			CaseSense::InsensitiveASCIIOnly=>ch.to_ascii_lowercase(),
-			CaseSense::Insensitive=>match ch.to_lowercase().len() {
-				1=> ch.to_lowercase().next().unwrap(),
-				_=>panic!("{:?} {} when converted to lowercase is a String not a character",ch,ch)
-			}
-			CaseSense::Sensitive=>ch
-		})
+            CaseSense::InsensitiveASCIIOnly => ch.to_ascii_lowercase(),
+            CaseSense::Insensitive => match ch.to_lowercase().len() {
+                1 => ch.to_lowercase().next().unwrap(),
+                _ => panic!(
+                    "{:?} {} when converted to lowercase is a String not a character",
+                    ch, ch
+                ),
+            },
+            CaseSense::Sensitive => ch,
+        })
         .fold(HashMap::new(), |mut fmap, ch| {
             *fmap.entry(ch).or_insert(0) += 1;
             fmap
@@ -210,235 +218,249 @@ mod tests {
 
     // convenience function for testing
     // given "a4 b3 c2 d1 e1", return hashmap {a:4, b:3, c:2, d;1, e:1}
-    fn hashfreq(s: &str) -> HashMap<char, usize> {
-        HashMap::<char, usize>::from_iter(s.split(" ").map(|chunk|
+    fn expected_freq(s: &str) -> HashMap<char, usize> {
+        HashMap::<char, usize>::from_iter(s.split(" ").map(|chunk| {
             (
                 chunk.chars().next().unwrap(),
-                usize::from_str_radix(&chunk.chars().skip(1).collect::<String>(), 10).unwrap()
+                usize::from_str_radix(&chunk.chars().skip(1).collect::<String>(), 10).unwrap(),
             )
-        ))
+        }))
     }
 
     #[test]
     fn test_character_frequencies_range_full() {
-        let result = character_frequencies_range("aaaabbbccd|@", 0, 11,CaseSense::InsensitiveASCIIOnly);
-        assert_eq!(result, hashfreq("a4 b3 c2 d1 |1 @1"));
+        let result =
+            character_frequencies_range("aaaabbbccd|@", 0, 11, CaseSense::InsensitiveASCIIOnly);
+        assert_eq!(result, expected_freq("a4 b3 c2 d1 |1 @1"));
     }
 
     #[test]
     fn test_character_frequencies_range_consecutive_left() {
-        let result = character_frequencies_range("aaaa", 0, 2,CaseSense::InsensitiveASCIIOnly);
-        assert_eq!(result, hashfreq("a3"));
+        let result = character_frequencies_range("aaaa", 0, 2, CaseSense::InsensitiveASCIIOnly);
+        assert_eq!(result, expected_freq("a3"));
     }
 
     #[test]
     fn test_character_frequencies_range_consecutive_right() {
-        let result = character_frequencies_range("aaaa", 1, 3,CaseSense::InsensitiveASCIIOnly);
-        assert_eq!(result, hashfreq("a3"));
+        let result = character_frequencies_range("aaaa", 1, 3, CaseSense::InsensitiveASCIIOnly);
+        assert_eq!(result, expected_freq("a3"));
     }
 
     #[test]
     fn test_character_frequencies_range_consecutive_center() {
-        let result = character_frequencies_range("aaaa", 1, 2,CaseSense::InsensitiveASCIIOnly);
-        assert_eq!(result, hashfreq("a2"));
-        let result = character_frequencies_range("baab", 1, 2,CaseSense::InsensitiveASCIIOnly);
-        assert_eq!(result, hashfreq("a2"));
-        let result = character_frequencies_range("bacb", 1, 2,CaseSense::InsensitiveASCIIOnly);
-        assert_eq!(result, hashfreq("a1 c1"));
-        let result = character_frequencies_range("dcab", 1, 2,CaseSense::InsensitiveASCIIOnly);
-        assert_eq!(result, hashfreq("a1 c1"));
+        let result = character_frequencies_range("aaaa", 1, 2, CaseSense::InsensitiveASCIIOnly);
+        assert_eq!(result, expected_freq("a2"));
+        let result = character_frequencies_range("baab", 1, 2, CaseSense::InsensitiveASCIIOnly);
+        assert_eq!(result, expected_freq("a2"));
+        let result = character_frequencies_range("bacb", 1, 2, CaseSense::InsensitiveASCIIOnly);
+        assert_eq!(result, expected_freq("a1 c1"));
+        let result = character_frequencies_range("dcab", 1, 2, CaseSense::InsensitiveASCIIOnly);
+        assert_eq!(result, expected_freq("a1 c1"));
     }
 
     #[test]
     fn test_character_frequencies_range_consecutive_whole() {
-        let result = character_frequencies_range("aaaa", 0, 3,CaseSense::InsensitiveASCIIOnly);
-        assert_eq!(result, hashfreq("a4"));
+        let result = character_frequencies_range("aaaa", 0, 3, CaseSense::InsensitiveASCIIOnly);
+        assert_eq!(result, expected_freq("a4"));
     }
 
     #[test]
     fn test_character_frequencies_range_only_one_left() {
-        let result = character_frequencies_range("aaa", 0, 0,CaseSense::InsensitiveASCIIOnly);
-        assert_eq!(result, hashfreq("a1"));
+        let result = character_frequencies_range("aaa", 0, 0, CaseSense::InsensitiveASCIIOnly);
+        assert_eq!(result, expected_freq("a1"));
     }
 
     #[test]
     fn test_character_frequencies_range_only_one_right() {
-        let result = character_frequencies_range("aaa", 2, 2,CaseSense::InsensitiveASCIIOnly);
-        assert_eq!(result, hashfreq("a1"));
+        let result = character_frequencies_range("aaa", 2, 2, CaseSense::InsensitiveASCIIOnly);
+        assert_eq!(result, expected_freq("a1"));
     }
 
     #[test]
     fn test_character_frequencies_range_only_one_center() {
-        let result = character_frequencies_range("aaa", 1, 1,CaseSense::InsensitiveASCIIOnly);
-        assert_eq!(result, hashfreq("a1"));
+        let result = character_frequencies_range("aaa", 1, 1, CaseSense::InsensitiveASCIIOnly);
+        assert_eq!(result, expected_freq("a1"));
     }
 
     #[test]
     fn test_sequential_character_frequencies() {
         let result = character_frequencies("aaaabbbccd|@");
-        assert_eq!(result, hashfreq("a4 b3 c2 d1 |1 @1"));
+        assert_eq!(result, expected_freq("a4 b3 c2 d1 |1 @1"));
     }
 
     #[test]
     fn test_parallel_character_frequencies_more_threads_than_characters() {
         let result = character_frequencies_with_n_threads("aaaabbbccd|@", 13);
-        assert_eq!(result, hashfreq("a4 b3 c2 d1 |1 @1"));
+        assert_eq!(result, expected_freq("a4 b3 c2 d1 |1 @1"));
     }
 
     #[test]
     fn test_parallel_character_frequencies_less_threads_than_characters() {
         let result = character_frequencies_with_n_threads("aaaabbbccd|@", 5);
-        assert_eq!(result, hashfreq("a4 b3 c2 d1 |1 @1"));
+        assert_eq!(result, expected_freq("a4 b3 c2 d1 |1 @1"));
     }
 
     #[test]
     fn test_parallel_character_frequencies_single_thread() {
         let result = character_frequencies_with_n_threads("aaaabbbccd|@", 1);
-        assert_eq!(result, hashfreq("a4 b3 c2 d1 |1 @1"));
+        assert_eq!(result, expected_freq("a4 b3 c2 d1 |1 @1"));
     }
 
     #[test]
     fn test_parallel_character_frequencies_prime_threads() {
         let result = character_frequencies_with_n_threads("aaaabbbccd|@", 7);
-        assert_eq!(result, hashfreq("a4 b3 c2 d1 |1 @1"));
+        assert_eq!(result, expected_freq("a4 b3 c2 d1 |1 @1"));
     }
 
     #[test]
     fn test_parallel_character_frequencies_n_threads() {
         let result = character_frequencies("aaaabbbccd|@");
-        assert_eq!(result, hashfreq("a4 b3 c2 d1 |1 @1"));
+        assert_eq!(result, expected_freq("a4 b3 c2 d1 |1 @1"));
     }
 
-        #[test]
-        fn test_character_frequencies_range_full_w_case() {
-            let result = character_frequencies_range("AaaaBbBCCd|@", 0, 11,CaseSense::Sensitive);
-            assert_eq!(result, hashfreq("a3 b1 C2 d1 |1 @1 A1 B2"));
-        }
+    #[test]
+    fn test_character_frequencies_range_full_w_case() {
+        let result = character_frequencies_range("AaaaBbBCCd|@", 0, 11, CaseSense::Sensitive);
+        assert_eq!(result, expected_freq("a3 b1 C2 d1 |1 @1 A1 B2"));
+    }
 
-        #[test]
-        fn test_character_frequencies_range_consecutive_left_w_case() {
-            let result = character_frequencies_range("aaaA", 0, 2,CaseSense::Sensitive);
-            assert_eq!(result, hashfreq("a3"));
-            let result = character_frequencies_range("Aaaa", 0, 2,CaseSense::Sensitive);
-            assert_eq!(result, hashfreq("a2 A1"));
-            let result = character_frequencies_range("AaAa", 0, 2,CaseSense::Sensitive);
-            assert_eq!(result, hashfreq("a1 A2"));
-        }
+    #[test]
+    fn test_character_frequencies_range_consecutive_left_w_case() {
+        let result = character_frequencies_range("aaaA", 0, 2, CaseSense::Sensitive);
+        assert_eq!(result, expected_freq("a3"));
+        let result = character_frequencies_range("Aaaa", 0, 2, CaseSense::Sensitive);
+        assert_eq!(result, expected_freq("a2 A1"));
+        let result = character_frequencies_range("AaAa", 0, 2, CaseSense::Sensitive);
+        assert_eq!(result, expected_freq("a1 A2"));
+    }
 
-        #[test]
-        fn test_character_frequencies_range_consecutive_right_w_case() {
-            let result = character_frequencies_range("Aaaa", 1, 3,CaseSense::Sensitive);
-            assert_eq!(result, hashfreq("a3"));
-            let result = character_frequencies_range("AaAa", 1, 3,CaseSense::Sensitive);
-            assert_eq!(result, hashfreq("a2 A1"));
-            let result = character_frequencies_range("AaaA", 1, 3,CaseSense::Sensitive);
-            assert_eq!(result, hashfreq("a2 A1"));
-        }
+    #[test]
+    fn test_character_frequencies_range_consecutive_right_w_case() {
+        let result = character_frequencies_range("Aaaa", 1, 3, CaseSense::Sensitive);
+        assert_eq!(result, expected_freq("a3"));
+        let result = character_frequencies_range("AaAa", 1, 3, CaseSense::Sensitive);
+        assert_eq!(result, expected_freq("a2 A1"));
+        let result = character_frequencies_range("AaaA", 1, 3, CaseSense::Sensitive);
+        assert_eq!(result, expected_freq("a2 A1"));
+    }
 
-        #[test]
-        fn test_character_frequencies_range_consecutive_center_w_case() {
-            let result = character_frequencies_range("aaaa", 1, 2,CaseSense::Sensitive);
-            assert_eq!(result, hashfreq("a2"));
-            let result = character_frequencies_range("baAb", 1, 2,CaseSense::Sensitive);
-            assert_eq!(result, hashfreq("a1 A1"));
-            let result = character_frequencies_range("bAcb", 1, 2,CaseSense::Sensitive);
-            assert_eq!(result, hashfreq("A1 c1"));
-            let result = character_frequencies_range("dcab", 1, 2,CaseSense::Sensitive);
-            assert_eq!(result, hashfreq("a1 c1"));
-        }
+    #[test]
+    fn test_character_frequencies_range_consecutive_center_w_case() {
+        let result = character_frequencies_range("aaaa", 1, 2, CaseSense::Sensitive);
+        assert_eq!(result, expected_freq("a2"));
+        let result = character_frequencies_range("baAb", 1, 2, CaseSense::Sensitive);
+        assert_eq!(result, expected_freq("a1 A1"));
+        let result = character_frequencies_range("bAcb", 1, 2, CaseSense::Sensitive);
+        assert_eq!(result, expected_freq("A1 c1"));
+        let result = character_frequencies_range("dcab", 1, 2, CaseSense::Sensitive);
+        assert_eq!(result, expected_freq("a1 c1"));
+    }
 
-        #[test]
-        fn test_character_frequencies_range_consecutive_whole_w_case() {
-            let result = character_frequencies_range("aaaa", 0, 3,CaseSense::Sensitive);
-            assert_eq!(result, hashfreq("a4"));
-            let result = character_frequencies_range("aAaa", 0, 3,CaseSense::Sensitive);
-            assert_eq!(result, hashfreq("A1 a3"));
-        }
+    #[test]
+    fn test_character_frequencies_range_consecutive_whole_w_case() {
+        let result = character_frequencies_range("aaaa", 0, 3, CaseSense::Sensitive);
+        assert_eq!(result, expected_freq("a4"));
+        let result = character_frequencies_range("aAaa", 0, 3, CaseSense::Sensitive);
+        assert_eq!(result, expected_freq("A1 a3"));
+    }
 
-        #[test]
-        fn test_character_frequencies_range_only_one_left_w_case() {
-            let result = character_frequencies_range("aaa", 0, 0,CaseSense::Sensitive);
-            assert_eq!(result, hashfreq("a1"));
-            let result = character_frequencies_range("AaA", 0, 0,CaseSense::Sensitive);
-            assert_eq!(result, hashfreq("A1"));
-        }
+    #[test]
+    fn test_character_frequencies_range_only_one_left_w_case() {
+        let result = character_frequencies_range("aaa", 0, 0, CaseSense::Sensitive);
+        assert_eq!(result, expected_freq("a1"));
+        let result = character_frequencies_range("AaA", 0, 0, CaseSense::Sensitive);
+        assert_eq!(result, expected_freq("A1"));
+    }
 
-        #[test]
-        fn test_character_frequencies_range_only_one_right_w_case() {
-            let result = character_frequencies_range("aaa", 2, 2,CaseSense::Sensitive);
-            assert_eq!(result, hashfreq("a1"));
-            let result = character_frequencies_range("BaA", 2, 2,CaseSense::Sensitive);
-            assert_eq!(result, hashfreq("A1"));
-        }
+    #[test]
+    fn test_character_frequencies_range_only_one_right_w_case() {
+        let result = character_frequencies_range("aaa", 2, 2, CaseSense::Sensitive);
+        assert_eq!(result, expected_freq("a1"));
+        let result = character_frequencies_range("BaA", 2, 2, CaseSense::Sensitive);
+        assert_eq!(result, expected_freq("A1"));
+    }
 
-        #[test]
-        fn test_character_frequencies_range_only_one_center_w_case() {
-            let result = character_frequencies_range("aaa", 1, 1,CaseSense::Sensitive);
-            assert_eq!(result, hashfreq("a1"));
-            let result = character_frequencies_range("aAa", 1, 1,CaseSense::Sensitive);
-            assert_eq!(result, hashfreq("A1"));
-        }
+    #[test]
+    fn test_character_frequencies_range_only_one_center_w_case() {
+        let result = character_frequencies_range("aaa", 1, 1, CaseSense::Sensitive);
+        assert_eq!(result, expected_freq("a1"));
+        let result = character_frequencies_range("aAa", 1, 1, CaseSense::Sensitive);
+        assert_eq!(result, expected_freq("A1"));
+    }
 
-        #[test]
-        fn test_sequential_character_frequencies_w_case() {
-            let result = character_frequencies_w_case("AaabbbccdEEE|@",CaseSense::Sensitive);
-            assert_eq!(result, hashfreq("A1 a2 b3 c2 d1 |1 @1 E3"));
-        }
+    #[test]
+    fn test_sequential_character_frequencies_w_case() {
+        let result = character_frequencies_w_case("AaabbbccdEEE|@", CaseSense::Sensitive);
+        assert_eq!(result, expected_freq("A1 a2 b3 c2 d1 |1 @1 E3"));
+    }
 
-        #[test]
-        fn test_parallel_character_frequencies_more_threads_than_characters_w_case() {
-            let result = character_frequencies_with_n_threads_w_case("AabbbccdE|@", 13,CaseSense::Sensitive);
-            assert_eq!(result, hashfreq("A1 a1 b3 c2 d1 |1 @1 E1"));
-        }
+    #[test]
+    fn test_parallel_character_frequencies_more_threads_than_characters_w_case() {
+        let result =
+            character_frequencies_with_n_threads_w_case("AabbbccdE|@", 13, CaseSense::Sensitive);
+        assert_eq!(result, expected_freq("A1 a1 b3 c2 d1 |1 @1 E1"));
+    }
 
-        #[test]
-        fn test_parallel_character_frequencies_less_threads_than_characters_w_case() {
-            let result = character_frequencies_with_n_threads_w_case("AaaabbbccdEEE|@", 5,CaseSense::Sensitive);
-            assert_eq!(result, hashfreq("A1 a3 b3 c2 d1 |1 @1 E3"));
-        }
+    #[test]
+    fn test_parallel_character_frequencies_less_threads_than_characters_w_case() {
+        let result =
+            character_frequencies_with_n_threads_w_case("AaaabbbccdEEE|@", 5, CaseSense::Sensitive);
+        assert_eq!(result, expected_freq("A1 a3 b3 c2 d1 |1 @1 E3"));
+    }
 
-        #[test]
-        fn test_parallel_character_frequencies_single_thread_w_case() {
-            let result = character_frequencies_with_n_threads_w_case("aaaAbbBccd|@", 1,CaseSense::Sensitive);
-            assert_eq!(result, hashfreq("a3 b2 B1 A1 c2 d1 |1 @1"));
-        }
+    #[test]
+    fn test_parallel_character_frequencies_single_thread_w_case() {
+        let result =
+            character_frequencies_with_n_threads_w_case("aaaAbbBccd|@", 1, CaseSense::Sensitive);
+        assert_eq!(result, expected_freq("a3 b2 B1 A1 c2 d1 |1 @1"));
+    }
 
-        #[test]
-        fn test_parallel_character_frequencies_prime_threads_w_case() {
-            let result = character_frequencies_with_n_threads_w_case("AaaBbbCcd|@",7,CaseSense::Sensitive);
-            assert_eq!(result, hashfreq("a2 A1 B1 b2 c1 C1 d1 |1 @1"));
-        }
+    #[test]
+    fn test_parallel_character_frequencies_prime_threads_w_case() {
+        let result =
+            character_frequencies_with_n_threads_w_case("AaaBbbCcd|@", 7, CaseSense::Sensitive);
+        assert_eq!(result, expected_freq("a2 A1 B1 b2 c1 C1 d1 |1 @1"));
+    }
 
-        #[test]
-        fn test_parallel_character_frequencies_n_threads_w_case() {
-            let result = character_frequencies_w_case("AaaBbbCcd|@",CaseSense::Sensitive);
-            assert_eq!(result, hashfreq("a2 A1 B1 b2 c1 C1 d1 |1 @1"));
-        }
+    #[test]
+    fn test_parallel_character_frequencies_n_threads_w_case() {
+        let result = character_frequencies_w_case("AaaBbbCcd|@", CaseSense::Sensitive);
+        assert_eq!(result, expected_freq("a2 A1 B1 b2 c1 C1 d1 |1 @1"));
+    }
 
-        #[test]
-        fn test_character_frequencies_unicode() {
-			let greek_upper = "ὈΔΥΣΣΕΎΣ";
-			let greek_lower = "ὀδυσσεύς";
-			let greek_mix = "ὀδυσσεύςὈΔΥΣΣΕΎΣ";
-            let resultu = character_frequencies_w_case(greek_upper,CaseSense::Sensitive);
-            let resultl = character_frequencies_w_case(greek_lower,CaseSense::Sensitive);
-            let resultm = character_frequencies_w_case(greek_mix,CaseSense::Sensitive);
-            assert_eq!(resultu, hashfreq("Ὀ1 Δ1 Υ1 Σ3 Ε1 Ύ1"));
-            assert_eq!(resultl, hashfreq("ὀ1 δ1 υ1 σ2 ε1 ς1 ύ1"));
-            assert_eq!(resultm, hashfreq("Ὀ1 Δ1 Υ1 Σ3 Ε1 Ύ1 ὀ1 δ1 υ1 σ2 ε1 ς1 ύ1"));
-            let resultu = character_frequencies_w_case(greek_upper,CaseSense::InsensitiveASCIIOnly);
-            let resultl = character_frequencies_w_case(greek_lower,CaseSense::InsensitiveASCIIOnly);
-            let resultm = character_frequencies_w_case(greek_mix,CaseSense::InsensitiveASCIIOnly);
-            assert_eq!(resultu, hashfreq("Ὀ1 Δ1 Υ1 Σ3 Ε1 Ύ1"));
-            assert_eq!(resultl, hashfreq("ὀ1 δ1 υ1 σ2 ε1 ς1 ύ1"));
-            assert_eq!(resultm, hashfreq("Ὀ1 Δ1 Υ1 Σ3 Ε1 Ύ1 ὀ1 δ1 υ1 σ2 ε1 ς1 ύ1"));
-            let resultu = character_frequencies_w_case(greek_upper,CaseSense::Insensitive);
-            let resultl = character_frequencies_w_case(greek_lower,CaseSense::Insensitive);
-            let resultm = character_frequencies_w_case(greek_mix,CaseSense::Insensitive);
-            assert_eq!(resultu, hashfreq("ὀ1 δ1 υ1 σ3 ε1 ύ1"));
-            assert_eq!(resultl, hashfreq("ὀ1 δ1 υ1 σ2 ε1 ς1 ύ1"));
-            assert_eq!(resultm, hashfreq("ὀ2 δ2 υ2 σ5 ε2 ς1 ύ2"));
-			
-        }
-
+    #[test]
+    fn test_character_frequencies_unicode() {
+        let greek_upper = "ὈΔΥΣΣΕΎΣ";
+        let greek_lower = "ὀδυσσεύς";
+        let greek_mix = "ὀδυσσεύςὈΔΥΣΣΕΎΣ";
+        let resultu_s = character_frequencies_w_case(greek_upper, CaseSense::Sensitive);
+        let resultl_s = character_frequencies_w_case(greek_lower, CaseSense::Sensitive);
+        let resultm_s = character_frequencies_w_case(greek_mix, CaseSense::Sensitive);
+        assert_eq!(resultu_s, expected_freq("Ὀ1 Δ1 Υ1 Σ3 Ε1 Ύ1"));
+        assert_eq!(resultl_s, expected_freq("ὀ1 δ1 υ1 σ2 ε1 ς1 ύ1"));
+        assert_eq!(
+            resultm_s,
+            expected_freq("Ὀ1 Δ1 Υ1 Σ3 Ε1 Ύ1 ὀ1 δ1 υ1 σ2 ε1 ς1 ύ1")
+        );
+        let resultu_ia = character_frequencies_w_case(greek_upper, CaseSense::InsensitiveASCIIOnly);
+        let resultl_ia = character_frequencies_w_case(greek_lower, CaseSense::InsensitiveASCIIOnly);
+        let resultm_ia = character_frequencies_w_case(greek_mix, CaseSense::InsensitiveASCIIOnly);
+        assert_eq!(resultu_s, resultu_ia);
+        assert_eq!(resultl_s, resultl_ia);
+        assert_eq!(resultm_s, resultm_ia);
+        let resultu_i = character_frequencies_w_case(greek_upper, CaseSense::Insensitive);
+        let resultl_i = character_frequencies_w_case(greek_lower, CaseSense::Insensitive);
+        let resultm_i = character_frequencies_w_case(greek_mix, CaseSense::Insensitive);
+        assert_eq!(resultu_i, expected_freq("ὀ1 δ1 υ1 σ3 ε1 ύ1"));
+        assert_eq!(resultl_i, expected_freq("ὀ1 δ1 υ1 σ2 ε1 ς1 ύ1"));
+        assert_eq!(resultm_i, expected_freq("ὀ2 δ2 υ2 σ5 ε2 ς1 ύ2"));
+        let chinese = "夫物芸芸，各復歸其根，歸根曰靜";
+        let expect_c = expected_freq("夫1 物1 芸2 ，2 各1 復1 其1 歸2 根2 曰1 靜1");
+        let resultc_s = character_frequencies_w_case(chinese, CaseSense::Sensitive);
+        let resultc_ia = character_frequencies_w_case(chinese, CaseSense::Insensitive);
+        let resultc_i = character_frequencies_w_case(chinese, CaseSense::InsensitiveASCIIOnly);
+        assert_eq!(resultc_s, expect_c);
+        assert_eq!(resultc_ia, expect_c);
+        assert_eq!(resultc_i, expect_c);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,9 +11,7 @@ use std::sync::{mpsc, Arc};
 use std::thread;
 
 /// This allows to count characters in a string while being sensitive to Case.
-/// This is done by translating 0 or more of the characters in the input string
-/// to lowercase before doing the frequency count.
-/// * InsensitiveASCIIOnly - ignores case only for ASCII characters, 
+/// * InsensitiveASCIIOnly - ignores case, but only for ASCII characters, 
 /// 'A' and 'a' are counted as the same but Greek letter 'Σ' is 
 /// counted as different from it's lowercase version 'σ' because it's not ASCII.
 /// Only ascii characters get converted to lowecase.
@@ -21,7 +19,7 @@ use std::thread;
 /// * Insensitive - ignores case based on Unicode Derived Core 
 /// Property Lowercase, so 'A'=='a' and also 'Σ'=='σ'.
 /// Note this does not deal with situations where case depends on position
-/// in a word. It changes characters to lowercase one at a time. 
+/// in a word. It changes all UTF8 characters to lowercase one at a time. 
 /// * Sensitive - Each character is counted separately.
 /// 'A' != 'a' and 'Σ'!='σ'. No characters are changed to lowercase.
 /// see https://doc.rust-lang.org/std/string/struct.String.html#method.to_ascii_lowercase
@@ -434,12 +432,12 @@ mod tests {
             assert_eq!(resultu, hashfreq("Ὀ1 Δ1 Υ1 Σ3 Ε1 Ύ1"));
             assert_eq!(resultl, hashfreq("ὀ1 δ1 υ1 σ2 ε1 ς1 ύ1"));
             assert_eq!(resultm, hashfreq("Ὀ1 Δ1 Υ1 Σ3 Ε1 Ύ1 ὀ1 δ1 υ1 σ2 ε1 ς1 ύ1"));
-/*            let resultu = character_frequencies_w_case(greek_upper,CaseSense::Insensitive);
+            let resultu = character_frequencies_w_case(greek_upper,CaseSense::Insensitive);
             let resultl = character_frequencies_w_case(greek_lower,CaseSense::Insensitive);
             let resultm = character_frequencies_w_case(greek_mix,CaseSense::Insensitive);
-            assert_eq!(resultu, hashfreq("Ὀ1 Δ1 Υ1 Σ3 Ε1 Ύ1"));
+            assert_eq!(resultu, hashfreq("ὀ1 δ1 υ1 σ3 ε1 ύ1"));
             assert_eq!(resultl, hashfreq("ὀ1 δ1 υ1 σ2 ε1 ς1 ύ1"));
-            assert_eq!(resultm, hashfreq("ὀ2 δ2 υ2 σ5 ε2 ς2 ύ1"));*/
+            assert_eq!(resultm, hashfreq("ὀ2 δ2 υ2 σ5 ε2 ς1 ύ2"));
 			
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ use std::thread;
 /// happens the code will panic!() if Insensitive is the CaseSense.
 /// * Sensitive - Each character is counted separately.
 /// 'A' != 'a' and 'Σ'!='σ'. No characters are changed to lowercase.
-/// see https://doc.rust-lang.org/std/string/struct.String.html#method.to_ascii_lowercase
+/// * See also <https://doc.rust-lang.org/std/string/struct.String.html#method.to_ascii_lowercase>
 #[derive(Clone, Copy)]
 pub enum CaseSense {
     Insensitive,
@@ -189,24 +189,20 @@ fn character_frequencies_range(
     to: usize,
     case_sense: CaseSense,
 ) -> HashMap<char, usize> {
-    text.chars()
+    let mut frequency_map: HashMap<char, usize> = HashMap::new();
+    for character in text.chars()
         .skip(from)
         .take(to - from + 1)
-        .map(|ch| match case_sense {
-            CaseSense::InsensitiveASCIIOnly => ch.to_ascii_lowercase(),
+		.map(|ch|  match case_sense {
             CaseSense::Insensitive => match ch.to_lowercase().len() {
                 1 => ch.to_lowercase().next().unwrap(),
-                _ => panic!(
-                    "Unicode character {:?} {} when converted to lowercase is a String not a character",
-                    ch, ch
-                ),
-            },
-            CaseSense::Sensitive => ch,
-        })
-        .fold(HashMap::new(), |mut fmap, ch| {
-            *fmap.entry(ch).or_insert(0) += 1;
-            fmap
-        })
+       	        _ => panic!("Unicode character {:?} {} when converted to lowercase is a multicharacter String not a character", ch, ch ),},
+            CaseSense::InsensitiveASCIIOnly => ch.to_ascii_lowercase(),
+            CaseSense::Sensitive=> ch,})
+        {
+            *frequency_map.entry(character).or_insert(0) += 1;
+        }
+    frequency_map
 }
 
 fn add_frequencies(a: HashMap<char, usize>, b: HashMap<char, usize>) -> HashMap<char, usize> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ pub fn character_frequencies(text: &str) -> HashMap<char, usize> {
     character_frequencies_with_n_threads(text, num_cpus::get())
 }
 
-/// Counts the frequencies of chars from a string with the ammount of threads specified.
+/// Counts the frequencies of chars from a string with the amount of threads specified.
 ///
 /// # Examples
 /// ```
@@ -160,8 +160,8 @@ fn add_frequencies(a: HashMap<char, usize>, b: HashMap<char, usize>) -> HashMap<
 mod tests {
     use super::*;
 
-    // given "a4 b3 c2 d1 e1", return {a:4, b:3, c:2, d;1, e:1} hashmap
-    // convenience for testing
+    // convenience function for testing
+    // given "a4 b3 c2 d1 e1", return hashmap {a:4, b:3, c:2, d;1, e:1}
     fn hashfreq(s: &str) -> HashMap<char, usize> {
         let mut hm: HashMap<char, usize> = HashMap::new();
         for i in s.split(" ") {
@@ -194,6 +194,12 @@ mod tests {
     fn test_character_frequencies_range_consecutive_center() {
         let result = character_frequencies_range("aaaa", 1, 2);
         assert_eq!(result, hashfreq("a2"));
+        let result = character_frequencies_range("baab", 1, 2);
+        assert_eq!(result, hashfreq("a2"));
+        let result = character_frequencies_range("bacb", 1, 2);
+        assert_eq!(result, hashfreq("a1 c1"));
+        let result = character_frequencies_range("dcab", 1, 2);
+        assert_eq!(result, hashfreq("a1 c1"));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,15 +10,15 @@ use std::sync::mpsc::Sender;
 use std::sync::{mpsc, Arc};
 use std::thread;
 
-/// This allows to count characters in a string while being sensitive to Case.
+/// CaseSense enables counting characters in a Case Sensitive way.
 /// * InsensitiveASCIIOnly - ignores case, but only for ASCII characters,
 /// 'A' and 'a' are counted as the same but Greek letter 'Σ' is
 /// counted as different from it's lowercase version 'σ' because it's not ASCII.
-/// Only ascii characters get converted to lowecase.
-/// For historical reasons, InsensitiveASCIIOnly is the default.
+/// Only ascii characters get converted to lowercase.
+/// InsensitiveASCIIOnly is the default.
 /// * Insensitive - ignores case based on Unicode Derived Core
 /// Property Lowercase, so 'A'=='a' and also 'Σ'=='σ'.
-/// Note this does not deal with situations where case depends on position
+/// This does not deal with situations where case depends on position
 /// in a word. It changes all UTF8 characters to lowercase one at a time.
 /// * Sensitive - Each character is counted separately.
 /// 'A' != 'a' and 'Σ'!='σ'. No characters are changed to lowercase.
@@ -60,6 +60,7 @@ pub fn character_frequencies(text: &str) -> HashMap<char, usize> {
     character_frequencies_with_n_threads(text, num_cpus::get())
 }
 
+/// same as character_frequences() but with Case Sensitivity
 pub fn character_frequencies_w_case(text: &str, case: CaseSense) -> HashMap<char, usize> {
     character_frequencies_with_n_threads_w_case(text, num_cpus::get(), case)
 }
@@ -94,6 +95,7 @@ pub fn character_frequencies_with_n_threads(text: &str, threads: usize) -> HashM
     character_frequencies_with_n_threads_w_case(text, threads, CaseSense::InsensitiveASCIIOnly)
 }
 
+/// same as character_frequencies_with_n_threads(), with Case Sensitivity
 pub fn character_frequencies_with_n_threads_w_case(
     text: &str,
     threads: usize,
@@ -171,6 +173,7 @@ pub fn sequential_character_frequencies(text: &str) -> HashMap<char, usize> {
     character_frequencies_range(text, 0, text.len() - 1, CaseSense::InsensitiveASCIIOnly)
 }
 
+// same as sequuential_character_frequencies but with Case Sensitivity
 pub fn sequential_character_frequencies_w_case(
     text: &str,
     case: CaseSense,
@@ -192,7 +195,7 @@ fn character_frequencies_range(
             CaseSense::Insensitive => match ch.to_lowercase().len() {
                 1 => ch.to_lowercase().next().unwrap(),
                 _ => panic!(
-                    "{:?} {} when converted to lowercase is a String not a character",
+                    "Unicode character {:?} {} when converted to lowercase is a String not a character",
                     ch, ch
                 ),
             },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -443,7 +443,7 @@ mod tests {
             resultm,
             expected_freq("Ὀ1 Δ1 Υ1 Σ3 Ε1 Ύ1 ὀ1 δ1 υ1 σ2 ε1 ς1 ύ1")
         );
-	}
+    }
 
     #[test]
     fn test_unicode_case_insensitiveasciionly() {
@@ -459,7 +459,7 @@ mod tests {
             resultm,
             expected_freq("Ὀ1 Δ1 Υ1 Σ3 Ε1 Ύ1 ὀ1 δ1 υ1 σ2 ε1 ς1 ύ1")
         );
-	}
+    }
 
     #[test]
     fn test_unicode_case_insensitive() {
@@ -472,7 +472,7 @@ mod tests {
         assert_eq!(resultu, expected_freq("ὀ1 δ1 υ1 σ3 ε1 ύ1"));
         assert_eq!(resultl, expected_freq("ὀ1 δ1 υ1 σ2 ε1 ς1 ύ1"));
         assert_eq!(resultm, expected_freq("ὀ2 δ2 υ2 σ5 ε2 ς1 ύ2"));
-	}
+    }
 
     #[test]
     fn test_unicode_case_irrelevant() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,164 +160,99 @@ fn add_frequencies(a: HashMap<char, usize>, b: HashMap<char, usize>) -> HashMap<
 mod tests {
     use super::*;
 
+    // given "a4 b3 c2 d1 e1", return {a:4, b:3, c:2, d;1, e:1} hashmap
+    // convenience for testing
+    fn hashfreq(s: &str) -> HashMap<char, usize> {
+        let mut hm: HashMap<char, usize> = HashMap::new();
+        for i in s.split(" ") {
+            let ch = i.chars().next().unwrap();
+            let num = usize::from_str_radix(i.get(1..).unwrap(), 10).unwrap();
+            hm.insert(ch, num);
+        }
+        hm
+    }
+
     #[test]
     fn test_character_frequencies_range_full() {
         let result = character_frequencies_range("aaaabbbccd|@", 0, 11);
-        let mut expected: HashMap<char, usize> = HashMap::new();
-        expected.insert('a', 4);
-        expected.insert('b', 3);
-        expected.insert('c', 2);
-        expected.insert('d', 1);
-        expected.insert('|', 1);
-        expected.insert('@', 1);
-
-        assert_eq!(result, expected);
+        assert_eq!(result, hashfreq("a4 b3 c2 d1 |1 @1"));
     }
 
     #[test]
     fn test_character_frequencies_range_consecutive_left() {
         let result = character_frequencies_range("aaaa", 0, 2);
-        let mut expected: HashMap<char, usize> = HashMap::new();
-        expected.insert('a', 3);
-
-        assert_eq!(result, expected);
+        assert_eq!(result, hashfreq("a3"));
     }
 
     #[test]
     fn test_character_frequencies_range_consecutive_right() {
         let result = character_frequencies_range("aaaa", 1, 3);
-        let mut expected: HashMap<char, usize> = HashMap::new();
-        expected.insert('a', 3);
-
-        assert_eq!(result, expected);
+        assert_eq!(result, hashfreq("a3"));
     }
 
     #[test]
     fn test_character_frequencies_range_consecutive_center() {
         let result = character_frequencies_range("aaaa", 1, 2);
-        let mut expected: HashMap<char, usize> = HashMap::new();
-        expected.insert('a', 2);
-
-        assert_eq!(result, expected);
+        assert_eq!(result, hashfreq("a2"));
     }
 
     #[test]
     fn test_character_frequencies_range_consecutive_whole() {
         let result = character_frequencies_range("aaaa", 0, 3);
-        let mut expected: HashMap<char, usize> = HashMap::new();
-        expected.insert('a', 4);
-
-        assert_eq!(result, expected);
+        assert_eq!(result, hashfreq("a4"));
     }
 
     #[test]
     fn test_character_frequencies_range_only_one_left() {
         let result = character_frequencies_range("aaa", 0, 0);
-        let mut expected: HashMap<char, usize> = HashMap::new();
-        expected.insert('a', 1);
-
-        assert_eq!(result, expected);
+        assert_eq!(result, hashfreq("a1"));
     }
 
     #[test]
     fn test_character_frequencies_range_only_one_right() {
         let result = character_frequencies_range("aaa", 2, 2);
-        let mut expected: HashMap<char, usize> = HashMap::new();
-        expected.insert('a', 1);
-
-        assert_eq!(result, expected);
+        assert_eq!(result, hashfreq("a1"));
     }
 
     #[test]
     fn test_character_frequencies_range_only_one_center() {
         let result = character_frequencies_range("aaa", 1, 1);
-        let mut expected: HashMap<char, usize> = HashMap::new();
-        expected.insert('a', 1);
-
-        assert_eq!(result, expected);
+        assert_eq!(result, hashfreq("a1"));
     }
 
     #[test]
     fn test_sequential_character_frequencies() {
         let result = character_frequencies("aaaabbbccd|@");
-        let mut expected: HashMap<char, usize> = HashMap::new();
-        expected.insert('a', 4);
-        expected.insert('b', 3);
-        expected.insert('c', 2);
-        expected.insert('d', 1);
-        expected.insert('|', 1);
-        expected.insert('@', 1);
-
-        assert_eq!(result, expected);
+        assert_eq!(result, hashfreq("a4 b3 c2 d1 |1 @1"));
     }
 
     #[test]
     fn test_parallel_character_frequencies_more_threads_than_characters() {
         let result = character_frequencies_with_n_threads("aaaabbbccd|@", 13);
-        let mut expected: HashMap<char, usize> = HashMap::new();
-        expected.insert('a', 4);
-        expected.insert('b', 3);
-        expected.insert('c', 2);
-        expected.insert('d', 1);
-        expected.insert('|', 1);
-        expected.insert('@', 1);
-
-        assert_eq!(result, expected);
+        assert_eq!(result, hashfreq("a4 b3 c2 d1 |1 @1"));
     }
 
     #[test]
     fn test_parallel_character_frequencies_less_threads_than_characters() {
         let result = character_frequencies_with_n_threads("aaaabbbccd|@", 5);
-        let mut expected: HashMap<char, usize> = HashMap::new();
-        expected.insert('a', 4);
-        expected.insert('b', 3);
-        expected.insert('c', 2);
-        expected.insert('d', 1);
-        expected.insert('|', 1);
-        expected.insert('@', 1);
-
-        assert_eq!(result, expected);
+        assert_eq!(result, hashfreq("a4 b3 c2 d1 |1 @1"));
     }
 
     #[test]
     fn test_parallel_character_frequencies_single_thread() {
         let result = character_frequencies_with_n_threads("aaaabbbccd|@", 1);
-        let mut expected: HashMap<char, usize> = HashMap::new();
-        expected.insert('a', 4);
-        expected.insert('b', 3);
-        expected.insert('c', 2);
-        expected.insert('d', 1);
-        expected.insert('|', 1);
-        expected.insert('@', 1);
-
-        assert_eq!(result, expected);
+        assert_eq!(result, hashfreq("a4 b3 c2 d1 |1 @1"));
     }
 
     #[test]
     fn test_parallel_character_frequencies_prime_threads() {
         let result = character_frequencies_with_n_threads("aaaabbbccd|@", 7);
-        let mut expected: HashMap<char, usize> = HashMap::new();
-        expected.insert('a', 4);
-        expected.insert('b', 3);
-        expected.insert('c', 2);
-        expected.insert('d', 1);
-        expected.insert('|', 1);
-        expected.insert('@', 1);
-
-        assert_eq!(result, expected);
+        assert_eq!(result, hashfreq("a4 b3 c2 d1 |1 @1"));
     }
 
     #[test]
     fn test_parallel_character_frequencies_n_threads() {
         let result = character_frequencies("aaaabbbccd|@");
-        let mut expected: HashMap<char, usize> = HashMap::new();
-        expected.insert('a', 4);
-        expected.insert('b', 3);
-        expected.insert('c', 2);
-        expected.insert('d', 1);
-        expected.insert('|', 1);
-        expected.insert('@', 1);
-
-        assert_eq!(result, expected);
+        assert_eq!(result, hashfreq("a4 b3 c2 d1 |1 @1"));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,14 @@ pub fn character_frequencies(text: &str) -> HashMap<char, usize> {
     character_frequencies_with_n_threads(text, num_cpus::get())
 }
 
-/// same as character_frequences() but with Case Sensitivity
+/// Same as character_frequences() but with Case Sensitivity
+///
+/// # Example
+/// ```
+/// use character_frequency::*;
+/// # use std::collections::HashMap;
+/// let frequency_map = character_frequencies_w_case("Hello, WORLD",CaseSense::Sensitive);
+/// ```
 pub fn character_frequencies_w_case(text: &str, case: CaseSense) -> HashMap<char, usize> {
     character_frequencies_with_n_threads_w_case(text, num_cpus::get(), case)
 }
@@ -98,6 +105,12 @@ pub fn character_frequencies_with_n_threads(text: &str, threads: usize) -> HashM
 }
 
 /// same as character_frequencies_with_n_threads(), with Case Sensitivity
+/// # Example
+/// ```
+/// use character_frequency::*;
+/// # use std::collections::HashMap;
+/// let frequency_map = character_frequencies_with_n_threads_w_case("Hello, WORLD",2,CaseSense::Sensitive);
+/// ```
 pub fn character_frequencies_with_n_threads_w_case(
     text: &str,
     threads: usize,
@@ -175,7 +188,13 @@ pub fn sequential_character_frequencies(text: &str) -> HashMap<char, usize> {
     character_frequencies_range(text, 0, text.len() - 1, CaseSense::InsensitiveASCIIOnly)
 }
 
-// same as sequuential_character_frequencies but with Case Sensitivity
+// Same as sequential_character_frequencies but with Case Sensitivity
+/// # Example
+/// ```
+/// use character_frequency::*;
+/// # use std::collections::HashMap;
+/// let frequency_map = sequential_character_frequencies_w_case("Hello, WORLD",CaseSense::Sensitive);
+/// ```
 pub fn sequential_character_frequencies_w_case(
     text: &str,
     case: CaseSense,
@@ -217,7 +236,7 @@ fn add_frequencies(a: HashMap<char, usize>, b: HashMap<char, usize>) -> HashMap<
 mod tests {
     use super::*;
 
-    // convenience function for testing
+    // convenience function for testing; simplifies giving expected frequencies.
     // given "a4 b3 c2 d1 e1", return hashmap {a:4, b:3, c:2, d;1, e:1}
     fn expected_freq(s: &str) -> HashMap<char, usize> {
         HashMap::<char, usize>::from_iter(s.split(" ").map(|chunk| {


### PR DESCRIPTION
this is a second attempt to do case sensitivity

the thing im most unsure about is the fact that when some unicode characters are "lowercased" they become strings. since this library is built on the idea of single characters only, the code just Panics if you try to lowercase one of those unusual unicode characters that becomes a string, and you have full "case insensitive" enabled (as opposed to case-insensitive-ascii-only). 

thanks